### PR TITLE
Stop updating docker hub description in CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,3 @@ jobs:
           command: |
             echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
             docker push circleci/runner:launch-agent
-      - run:
-          name: "Publish Docker Hub Description"
-          command: |
-            # Update the Docker Hub description
-            STUBB_VER=0.2.0
-            STUBB_URL="https://github.com/CircleCI-Public/stubb/releases/download/v${STUBB_VER}/stubb_${STUBB_VER}-linux-amd64.tar.gz"
-            curl -sSL $STUBB_URL | tar -xz -C /usr/local/bin stubb
-
-            DOCKER_PASS=$DOCKER_TOKEN stubb set description circleci/runner ./README.md


### PR DESCRIPTION
- The stubb program is a bit buggy and hides a current API limitation that
  circlecipublicimage+token can't be used to update image README, but
  circlecipublicimage+password does work.  see https://github.com/CircleCI-Public/stubb/pull/14
