### PR TITLE
Use exec to start launch-agent for signal passing

### DIFF
--- a/launch-agent/start.sh
+++ b/launch-agent/start.sh
@@ -29,4 +29,4 @@ sed -i s/CIRCLECI_RUNNER_NAME/$(hostname)/ /opt/circleci/launch-agent-config.yam
 
 sed -i s=CIRCLECI_RESOURCE_CLASS=${CIRCLECI_RESOURCE_CLASS}= /opt/circleci/launch-agent-config.yaml
 
-/opt/circleci/circleci-launch-agent --config /opt/circleci/launch-agent-config.yaml
+exec /opt/circleci/circleci-launch-agent --config /opt/circleci/launch-agent-config.yaml


### PR DESCRIPTION
- Before this fix, Ctrl-c didn't work as the signal is captured by the Bash script.
