### PR TITLE
Le/build image with la binary [RT-21]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,12 @@
 version: 2.1
 
+parameters:
+  agent_version:
+    type: string
+    description: version of launch-agent to build into Docker image (e.g. 1.0.16645-31711f7); use latest if not specified
+    default: ""
+
+
 workflows:
   launch-agent:
     jobs:
@@ -10,34 +17,57 @@ workflows:
           filters:
             branches:
               only: main
-          context: runner-publishing
+          context: cimg-publishing
 
 jobs:
   launch-agent-test:
     docker:
-      - image: cibuilds/docker:19.03
+      - image: cimg/base:stable-20.04
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - run:
-          name: "Build Dockerfiles"
+          name: "Build Docker image"
           working_directory: ./launch-agent
           command: |
-            docker build --file Dockerfile -t circleci/runner:launch-agent .
+            latest_version=`./get-latest-agent-version.sh`
+            if [ -z "<< pipeline.parameters.agent_version >>" ]; then
+              agent_version="$latest_version"
+            else
+              agent_version="<< pipeline.parameters.agent_version >>"
+            fi
+            echo "agent_version is $agent_version"
+            docker build --build-arg agent_version=$agent_version --file Dockerfile -t circleci/runner:testing .
 
   launch-agent-build-and-publish:
     docker:
-      - image: cibuilds/docker:19.03
+      - image: cimg/base:stable-20.04
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - run:
-          name: "Build & Tag Images"
+          name: "Build & Tag Docker Image"
           working_directory: ./launch-agent
           command: |
-            docker build --file Dockerfile -t circleci/runner:launch-agent .
+            latest_version=`./get-latest-agent-version.sh`
+            if [ -z "<< pipeline.parameters.agent_version >>" ]; then
+              agent_version=$latest_version
+            else
+              agent_version="<< pipeline.parameters.agent_version >>"
+            fi
+
+            tags="-t circleci/runner:$agent_version"
+
+            # if using the latest agent, also apply the "runner" tag
+            if [ "$agent_version" = "$latest_version" ]; then
+              tags="$tags -t circleci/runner:runner"
+            fi
+
+            docker build --build-arg agent_version=$agent_version --file Dockerfile $tags .
       - deploy:
           name: "Publish Docker Image"
           command: |
             echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-            docker push circleci/runner:launch-agent
+            docker push circleci/runner --all-tags

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In the future a variant will be added that runs the `launch-agent` runs on the h
 
 ## Getting Started
 
-This image can be used a host with docker installed:
+This image can be used on a host with docker installed:
 
 ```bash
 CIRCLECI_RESOURCE_CLASS=<resource-class> CIRCLECI_API_TOKEN=<runner-token> docker run --env CIRCLECI_API_TOKEN --env CIRCLECI_RESOURCE_CLASS --name <container-name> circleci/runner:launch-agent

--- a/launch-agent/Dockerfile
+++ b/launch-agent/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ARG agent_version
+
 RUN apt-get update && apt-get install -y \
                                         curl \
                                         gzip \
@@ -10,12 +12,16 @@ RUN apt-get update && apt-get install -y \
                                         jq && \
                                         rm -rf /var/lib/apt/lists/*
 
+COPY --chown=root:root init-launch-agent.sh /root/init-launch-agent.sh
+RUN chmod +x /root/init-launch-agent.sh
+RUN /root/init-launch-agent.sh $agent_version
+
 COPY --chown=root:root start.sh /root/start.sh
-COPY --chown=root:root launch-task /opt/circleci/launch-task
+COPY --chown=root:root launch-task.sh /opt/circleci/launch-task.sh
 COPY --chown=root:root launch-agent-config.yaml /opt/circleci/launch-agent-config.yaml
 
 RUN chmod 600 /opt/circleci/launch-agent-config.yaml && \
-                                        chmod 755 /opt/circleci/launch-task && \
+                                        chmod 755 /opt/circleci/launch-task.sh && \
                                         chmod +x /root/start.sh && \
                                         chmod 755 /root
 

--- a/launch-agent/get-latest-agent-version.sh
+++ b/launch-agent/get-latest-agent-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
+agent_version=${agent_version:-$(curl -s "$base_url/release.txt")}
+echo "$agent_version"

--- a/launch-agent/init-launch-agent.sh
+++ b/launch-agent/init-launch-agent.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${1-}" ]; then
+  echo "Launch-agent version must be specified."
+  exit 1
+fi
+agent_version="${1-}"
+echo "Using CircleCI Launch Agent version $agent_version"
+
+base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
+prefix=/opt/circleci
+mkdir -p "$prefix/workdir"
+
+echo "Downloading and verifying CircleCI Launch Agent Binary"
+curl -sSL "$base_url/$agent_version/checksums.txt" -o checksums.txt
+IFS=" " read -r -a selected <<< "$(grep -F "linux/amd64" checksums.txt)"
+
+file=${selected[1]:1}
+mkdir -p "linux/amd64"
+echo "Downloading CircleCI Launch Agent: $file"
+curl --compressed -L "$base_url/$agent_version/$file" -o "$file"
+
+echo "Verifying CircleCI Launch Agent download"
+sha256sum --check --ignore-missing checksums.txt && chmod +x "$file"; mv "$file" "$prefix/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"
+rm checksums.txt
+
+echo "Adding circleci user"
+id -u circleci &>/dev/null || adduser --uid 1500 --disabled-password --gecos GECOS circleci
+chown -R circleci ${prefix}/workdir

--- a/launch-agent/launch-agent-config.yaml
+++ b/launch-agent/launch-agent-config.yaml
@@ -3,6 +3,7 @@ api:
 runner:
   name: CIRCLECI_RUNNER_NAME
   resource_class: CIRCLECI_RESOURCE_CLASS
-  command_prefix: ["/opt/circleci/launch-task"]
+  command_prefix: ["/opt/circleci/launch-task.sh"]
   working_directory: /opt/circleci/workdir/%s
+  disable_auto_update: true
   cleanup_working_directory: true

--- a/launch-agent/launch-task.sh
+++ b/launch-agent/launch-task.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # Give the transient systemd unit an inteligible name
 # unit="circleci-$CIRCLECI_LAUNCH_ID"
 
-sudo -H -u circleci $@
+sudo -H -u circleci "$@"
 # When this process exits, tell the systemd unit to shut down
 # abort() {
 #   systemctl stop "$unit"

--- a/launch-agent/start.sh
+++ b/launch-agent/start.sh
@@ -1,32 +1,14 @@
 #!/bin/bash
 prefix=/opt/circleci
-mkdir -p "$prefix/workdir"
-base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
-echo "Determining latest version of CircleCI Launch Agent"
-agent_version=${agent_version:-$(curl "$base_url/release.txt")}
-echo "Using CircleCI Launch Agent version $agent_version"
-echo "Downloading and verifying CircleCI Launch Agent Binary"
-curl -sSL "$base_url/$agent_version/checksums.txt" -o checksums.txt
-IFS=" " read -r -a selected <<< "$(grep -F "linux/amd64" checksums.txt)"
-checksum=${selected[0]}
-file=${selected[1]:1}
-mkdir -p "linux/amd64"
-echo "Downloading CircleCI Launch Agent: $file"
-curl --compressed -L "$base_url/$agent_version/$file" -o "$file"
-echo "Verifying CircleCI Launch Agent download"
-sha256sum --check --ignore-missing checksums.txt && chmod +x "$file"; mv "$file" "$prefix/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"
-id -u circleci &>/dev/null || adduser --uid 1500 --disabled-password --gecos GECOS circleci
-chown -R circleci /opt/circleci/workdir
-
 if [[ -z "${CIRCLECI_API_TOKEN}" ]]; then
   echo "No API token supplied; exiting"
   exit 1
 else
-  sed -i s/CIRCLECI_API_TOKEN/${CIRCLECI_API_TOKEN}/ /opt/circleci/launch-agent-config.yaml
+  sed -i s/CIRCLECI_API_TOKEN/"${CIRCLECI_API_TOKEN}"/ $prefix/launch-agent-config.yaml
 fi
 
-sed -i s/CIRCLECI_RUNNER_NAME/$(hostname)/ /opt/circleci/launch-agent-config.yaml
+sed -i s/CIRCLECI_RUNNER_NAME/"$(hostname)"/ $prefix/launch-agent-config.yaml
 
-sed -i s=CIRCLECI_RESOURCE_CLASS=${CIRCLECI_RESOURCE_CLASS}= /opt/circleci/launch-agent-config.yaml
+sed -i s=CIRCLECI_RESOURCE_CLASS="${CIRCLECI_RESOURCE_CLASS}"= $prefix/launch-agent-config.yaml
 
-exec /opt/circleci/circleci-launch-agent --config /opt/circleci/launch-agent-config.yaml
+exec $prefix/circleci-launch-agent --config $prefix/launch-agent-config.yaml


### PR DESCRIPTION
- move launch-agent download and initialization into docker image build step
- consistently name scripts with ".sh" suffix
- shecllcheck scripts
- Dockerfile accepts "agent_version" build argument used in automation
- add "agent_version" pipeline argument
- always tag Docker image with version of launch-agent
- also apply "runner" tag when building against latest release of runner
- fix typo in README


----

# Next Step

launch-agent pipeline adds a job to trigger the main workflow to CD changes.