### PR TITLE
support linux/[amd|arm]64 multi manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ parameters:
     description: version of launch-agent to build into Docker image (e.g. 1.0.16645-31711f7); use latest if not specified
     default: ""
 
-
 workflows:
   launch-agent:
     jobs:
@@ -27,8 +26,9 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.7
+      - initialize_multiarch_builder
       - run:
-          name: "Build Docker image"
+          name: "Build Docker images"
           working_directory: ./launch-agent
           command: |
             latest_version=`./get-latest-agent-version.sh`
@@ -38,7 +38,8 @@ jobs:
               agent_version="<< pipeline.parameters.agent_version >>"
             fi
             echo "agent_version is $agent_version"
-            docker build --build-arg agent_version=$agent_version --file Dockerfile -t circleci/runner:testing .
+            # We have to push with buildx for now, so that we can use it's multiarch manifest support https://www.docker.com/blog/multi-arch-images/
+            docker buildx build --platform linux/arm64,linux/amd64 --build-arg agent_version=$agent_version --file Dockerfile -t circleci/runner:testing .
 
   launch-agent-build-and-publish:
     docker:
@@ -47,8 +48,9 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.7
+      - initialize_multiarch_builder
       - run:
-          name: "Build & Tag Docker Image"
+          name: "Build, Tag, and Push Docker Image Manifests"
           working_directory: ./launch-agent
           command: |
             latest_version=`./get-latest-agent-version.sh`
@@ -64,10 +66,19 @@ jobs:
             if [ "$agent_version" = "$latest_version" ]; then
               tags="$tags -t circleci/runner:runner"
             fi
-
-            docker build --build-arg agent_version=$agent_version --file Dockerfile $tags .
-      - deploy:
-          name: "Publish Docker Image"
-          command: |
+            
             echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-            docker push circleci/runner --all-tags
+            # We have to push with buildx for now, so that we can use it's multiarch manifest support https://www.docker.com/blog/multi-arch-images/
+            docker buildx build --platform linux/amd64,linux/arm64 --build-arg agent_version=$agent_version --file Dockerfile $tags --push . 
+
+
+commands:
+  initialize_multiarch_builder:
+    description: "Initialize a docker build for multi-architecture image manifests"
+    steps:
+      - run: "docker context create remote-context"
+      - run: "docker buildx create remote-context --name multi-arch-builder"
+      - run: "docker buildx use multi-arch-builder"
+      # make sure qemu emulators are installed
+      # The tonistiigi/binfmt image is what's recommended from the docker docs https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
+      - run: "docker run -it --rm --privileged tonistiigi/binfmt --install arm64"

--- a/launch-agent/Dockerfile
+++ b/launch-agent/Dockerfile
@@ -1,20 +1,14 @@
 FROM ubuntu:20.04
 
 ARG agent_version
+ARG TARGETPLATFORM
 
-RUN apt-get update && apt-get install -y \
-                                        curl \
-                                        gzip \
-                                        sudo \
-                                        wget \
-                                        apt-transport-https \
-                                        unzip \
-                                        jq && \
-                                        rm -rf /var/lib/apt/lists/*
+RUN apt update 
+RUN apt install -y curl gzip sudo wget apt-transport-https unzip jq
+RUN rm -rf /var/lib/apt/lists/*
 
 COPY --chown=root:root init-launch-agent.sh /root/init-launch-agent.sh
-RUN chmod +x /root/init-launch-agent.sh
-RUN /root/init-launch-agent.sh $agent_version
+RUN /bin/bash /root/init-launch-agent.sh $agent_version $TARGETPLATFORM
 
 COPY --chown=root:root start.sh /root/start.sh
 COPY --chown=root:root launch-task.sh /opt/circleci/launch-task.sh

--- a/launch-agent/init-launch-agent.sh
+++ b/launch-agent/init-launch-agent.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+target_platform="$2"
+
 if [ -z "${1-}" ]; then
   echo "Launch-agent version must be specified."
   exit 1
@@ -14,10 +16,10 @@ mkdir -p "$prefix/workdir"
 
 echo "Downloading and verifying CircleCI Launch Agent Binary"
 curl -sSL "$base_url/$agent_version/checksums.txt" -o checksums.txt
-IFS=" " read -r -a selected <<< "$(grep -F "linux/amd64" checksums.txt)"
+IFS=" " read -r -a selected <<< "$(grep -F "$target_platform" checksums.txt)"
 
 file=${selected[1]:1}
-mkdir -p "linux/amd64"
+mkdir -p "$target_platform"
 echo "Downloading CircleCI Launch Agent: $file"
 curl --compressed -L "$base_url/$agent_version/$file" -o "$file"
 


### PR DESCRIPTION
* Use the `buildx` docker command to build a multiarch manifest for the runner docker image
* Support ARM64 docker hosts
* CircleCI job running on an ARM64 docker executor (CCI internal link) https://app.circleci.com/pipelines/github/circleci/runner-dummy/130/workflows/c63fb504-ebef-4ccc-ab5c-3de35c97f509/jobs/312