### PR TITLE
Remove deprecated --env flag

### DIFF
--- a/launch-agent/start.sh
+++ b/launch-agent/start.sh
@@ -18,4 +18,4 @@ export LAUNCH_AGENT_RUNNER_WORK_DIR="/opt/circleci/workdir/%s"
 export LAUNCH_AGENT_RUNNER_DISABLE_AUTO_UPDATE=true
 export LAUNCH_AGENT_RUNNER_CLEANUP_WORK_DIR=true
 
-exec $prefix/circleci-launch-agent --env
+exec $prefix/circleci-launch-agent


### PR DESCRIPTION
No longer needed for configuration via env vars.