### PR TITLE
set noninteractive frontend for headless ops

### DIFF
--- a/launch-agent/Dockerfile
+++ b/launch-agent/Dockerfile
@@ -15,6 +15,7 @@ RUN mkdir -p /opt/circleci/workdir
 RUN chown -R circleci:circleci /opt/circleci
 
 RUN echo "circleci ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/circleci
+RUN echo "DEBIAN_FRONTEND=noninteractive" > /etc/environment
 
 USER circleci
 


### PR DESCRIPTION
Set the environment for **all** operations to be noninteractive in the `/etc/environment` file. Putting it in here instead of the bash profile makes sure it persists for sudo commands as well. 