### PR TITLE
fix hyperdoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We encourage [issues](https://github.com/CircleCI-Public/circleci-runner-docker/
 
 - [Dockerhub Repository](https://hub.docker.com/r/circleci/runner) - DockerHub repository for the runner image
 - [CircleCI Docs](https://circleci.com/docs/) - The official CircleCI Documentation website.
-- [Runner Docs][https://circleci.com/docs/2.0/runner-overview/]
+- [Runner Docs](https://circleci.com/docs/2.0/runner-overview/)
 - [Docker Docs](https://docs.docker.com/)
 
 ## Container orchestrators


### PR DESCRIPTION
Permissions for pipelines for forked PRs caused https://github.com/CircleCI-Public/circleci-runner-docker/pull/19 to not be able to complete CI. This is to bring @felixshiftellecon changes into the readme. 